### PR TITLE
Separate the 'get' and 'start' scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,25 @@ $ bash get-game.sh
 
 To make it as easy as possible to get and start the docker images, the `get-game.ps1` powershell script is available on S3. Running the latest build of the game and web server takes three steps:
 
-1. Download the script
+1. Download the scripts
 
 ```powershell
 PS:\> curl -Uri https://hacko-cdn.s3-us-west-2.amazonaws.com/earthquake-heroes/get-game.ps1 -OutFile get-game.ps1
+PS:\> curl -Uri https://hacko-cdn.s3-us-west-2.amazonaws.com/earthquake-heroes/start-game.ps1 -OutFile start-game.ps1
 ```
 
 2. Edit the script to provide values for the AWS environment variables. If you are meant to run the game, you'll have credentials.
 
-3. Run the script
+3. Run the get-game script to pull docker containers
 
 ```powershell
 PS:\> & .\get-game.ps1
 ```
 
+4. Run the start-game script to run the tileserver and the game!
+
+```powershell
+PS:\> & .\start-game.ps1
+```
 
 **:warning: Note! These scripts require Docker, Git and the AWS CLI to be installed already.**

--- a/start-game.ps1
+++ b/start-game.ps1
@@ -10,5 +10,5 @@ Set-Location -Path earthquake-heroes
 # Authenticate with ECR
 Invoke-Expression -Command (aws ecr get-login --no-include-email --region us-west-2)
 
-# Get the docker images
-docker-compose pull
+# Start the tile server and the game!
+docker-compose up


### PR DESCRIPTION
This makes the repo match what we did on-site at OMSI. 

The rationale behind it is pulling images can be a time-consuming surprise, so let's make that a deliberate action.